### PR TITLE
Fix dynamic core CoreData initialization

### DIFF
--- a/source/boundary_temperature/dynamic_core.cc
+++ b/source/boundary_temperature/dynamic_core.cc
@@ -94,9 +94,16 @@ namespace aspect
 
           const Postprocess::CoreStatistics<dim> &core_statistics
             = this->get_postprocess_manager().template get_matching_active_plugin<const Postprocess::CoreStatistics<dim>>();
+          const internal::CoreData &postprocessor_core_data = core_statistics.get_core_data();
+          const bool restored_core_data = postprocessor_core_data.is_initialized;
+
           // The restart data is stored in 'core statistics' postprocessor.
           // If restart from checkpoint, extract data from there.
-          core_data = core_statistics.get_core_data();
+          // In a fresh run, the postprocessor has not seen valid dynamic core
+          // data yet, so keep the boundary model's CoreData object and
+          // initialize it from the parameter file below.
+          if (restored_core_data)
+            core_data = postprocessor_core_data;
 
           // Read data of other energy source
           read_data_OES();
@@ -130,6 +137,7 @@ namespace aspect
               core_data.Xi = compute_X(core_data.Ri);
 
               core_data.Q = 0.;
+              core_data.H = 0.;
               core_data.dt = 0.;
               core_data.dT_dt = init_dT_dt;
               core_data.dR_dt = init_dR_dt;
@@ -146,6 +154,12 @@ namespace aspect
                     <<std::setw(15)<<core_data.dT_dt *year_in_seconds<<std::setw(15)<<core_data.dR_dt/1.e3 *year_in_seconds
                     <<std::setw(15)<<core_data.dX_dt *year_in_seconds<<std::endl;
               this->get_pcout() << output.str();
+            }
+          else if (restored_core_data)
+            {
+              core_data.dt = this->get_timestep();
+              core_data.H = compute_radioheating_rate();
+              update_core_data();
             }
           is_first_call = false;
         }


### PR DESCRIPTION
This is a small follow-up patch for geodynamics/aspect#6924.

It avoids copying `CoreData` from the `CoreStatistics` postprocessor on fresh runs, where the postprocessor data has not been initialized yet. In that path, `core_data.H` is initialized to `0.`. On restart, the restored postprocessor `CoreData` is still used, and the current `dt`, `H`, and derived core quantities are recomputed before continuing.

@gassmoeller, does this match the initialization behavior you had in mind, and do you think it fully resolves the `CoreData` issue you pointed out?

Checks run locally:
- Debug build: passed
- No-unity debug build: passed
- Dynamic core restart smoke test: passed
- `dynamic_core`: passed
- `dynamic_core_fully_solid`: passed
- `dynamic_core_fully_molten`: only a local last-digit statistics diff, no SIGFPE
